### PR TITLE
Add all the bindings to magic.api/compile-namespace

### DIFF
--- a/Infrastructure/Compiler/magic/api.clj
+++ b/Infrastructure/Compiler/magic/api.clj
@@ -10,6 +10,7 @@
              [lift-vars :refer [lift-vars]]
              [lift-keywords :refer [lift-keywords]]]
             [magic.emission :refer [*module* fresh-module]]
+            [clojure.main :as main]
             [clojure.string :as string])
   (:import [clojure.lang RT LineNumberingTextReader]
            [System.Reflection MethodAttributes TypeAttributes]
@@ -237,7 +238,7 @@
   (println "[compile-namespace]" namespace)
   (when-let [path (find-file roots namespace)]
     (with-redefs [clojure.core/load-one (fn magic-load-one-fn [lib need-ns require]
-                                          (binding [*ns* *ns*]
+                                          (main/with-bindings
                                             (compile-namespace roots lib)
                                             (dosync
                                              (commute (loaded-libs-ref) conj lib))))]


### PR DESCRIPTION
close #7

This PR solves the binding issues with the external libraries (`*unchecked-math*`, `*warning-on-reflection*` etc).

The custom clojure dynamic var used in nostrand such as *load-fn* are still not handled. (`clojure.core.clj` is still different in `Magic` and `Magic.Unity` in that regards.