### PR TITLE
Add meta back to prevent dll duplication errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Clojure
+.clj-kondo
+.lsp
+
+# C#
+bin
+obj
+nuget.config
+
+# Mac
+.DS_Store

--- a/Magic.Unity.nuspec
+++ b/Magic.Unity.nuspec
@@ -13,18 +13,18 @@
     </metadata>
     <files>
       <!-- clojure dlls -->
-      <file src="Infrastructure\Nostrand\clojure*.clj.dll" target="lib\netstandard2.0\Clojure" />
+      <file src="Infrastructure\Nostrand\clojure*.clj.dll*" target="lib\netstandard2.0\Clojure" />
       <!-- magic dlls -->
-      <file src="Infrastructure\Nostrand\mage*.clj.dll" target="lib\netstandard2.0\Magic" />
-      <file src="Infrastructure\Nostrand\magic*.clj.dll" target="lib\netstandard2.0\Magic" />
-      <file src="Infrastructure\Nostrand\LineEditor.dll" target="lib\netstandard2.0\Magic" />
+      <file src="Infrastructure\Nostrand\mage*.clj.dll*" target="lib\netstandard2.0\Magic" />
+      <file src="Infrastructure\Nostrand\magic*.clj.dll*" target="lib\netstandard2.0\Magic" />
+      <file src="Infrastructure\Nostrand\LineEditor.dll*" target="lib\netstandard2.0\Magic" />
       <!-- Runtime dlls -->
-      <file src="Infrastructure\Nostrand\Clojure.dll" target="lib\netstandard2.0\Clojure.Runtime" />
-      <file src="Infrastructure\Nostrand\Magic.Runtime*.dll" target="lib\netstandard2.0\Magic.Runtime" />
+      <file src="Infrastructure\Nostrand\Clojure.dll*" target="lib\netstandard2.0\Clojure.Runtime" />
+      <file src="Infrastructure\Nostrand\Magic.Runtime*.dll*" target="lib\netstandard2.0\Magic.Runtime" />
       <!-- IL2CPP dlls -->
-      <file src="Infrastructure\IL2CPP\*" target="lib\netstandard2.0\IL2CPP" exclude="**/*.meta"/>
+      <file src="Infrastructure\IL2CPP\*" target="lib\netstandard2.0\IL2CPP"/>
       <!-- Magic.Unity cs -->
-      <file src="Magic.Unity.cs" target="content"/>
-      <file src="Editor\*.cs" target="content\Editor"/>
+      <file src="Magic.Unity.cs*" target="content"/>
+      <file src="Editor\*.cs*" target="content\Editor"/>
     </files>
 </package>


### PR DESCRIPTION
Closes #18

- Add meta files back to prevent duplication errors in Unity due to version conflicts.
- Add .gitignore
- New package pushed in the forked repo